### PR TITLE
Add .travis.yml for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# Copied from https://github.com/theia-ide/theia-csharp-extension/blob/master/.travis.yml
+#
+# Copyright (C) 2018 TypeFox and others.
+# This program and the accompanying materials are made available under the terms of the
+# Eclipse Public License v2.0 which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+
+dist: xenial
+sudo: required
+language: node_js
+node_js: '10'
+git:
+  depth: 1
+cache:
+  yarn: true
+  directories:
+  - node_modules
+branches:
+  only:
+  - master
+install:
+- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+- export PATH=$HOME/.yarn/bin:$PATH ;
+script:
+- yarn
+before_deploy:
+- printf "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n" >> ~/.npmrc
+deploy:
+  provider: script
+  script: yarn run publish:next
+  skip_cleanup: true
+  on:
+    branch: master


### PR DESCRIPTION
Added the `.travis.yml` file to enable Travis CI on the repo and trigger publishing next versions to npm.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>